### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 An [MCP server](https://modelcontextprotocol.io/introduction) for MotherDuck and local DuckDB. 
 
+<a href="https://glama.ai/mcp/servers/15mdwrzibz"><img width="380" height="200" src="https://glama.ai/mcp/servers/15mdwrzibz/badge" alt="mcp-server-motherduck MCP server" /></a>
+
 ## Components
 
 ### Resources


### PR DESCRIPTION
This PR adds a badge for the [mcp-server-motherduck](https://glama.ai/mcp/servers/15mdwrzibz) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/15mdwrzibz"><img width="380" height="200" src="https://glama.ai/mcp/servers/15mdwrzibz/badge" alt="mcp-server-motherduck MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.