### PR TITLE
Fix uv installation instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ All interactions with both DuckDB and MotherDuck are done through writing SQL qu
 
 - A MotherDuck account (sign up at [motherduck.com](https://motherduck.com))
 - A MotherDuck access token
-- `uvx` installed, you can install it using `pip install uvx` or `brew install uvx`
+- `uv` installed, you can install it using `pip install uv` or `brew install uv`
 
 If you plan to use MotherDuck MCP with Claude Desktop, you will also need Claude Desktop installed.
 


### PR DESCRIPTION
This PR fixes a mistake in the README.md file regarding the installation instructions for `uv`.

The current README incorrectly states:
- `pip install uvx` 
- `brew install uvx`

The correct commands should be:
- `pip install uv`
- `brew install uv`

`uvx` is actually a command/alias for `uv tool run` after installing `uv`, not a separate package.

References:
- https://docs.astral.sh/uv/getting-started/installation/
- https://docs.astral.sh/uv/guides/tools/ (for uvx command information)