### PR TITLE
Fix syntax example on cursor rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,16 +54,18 @@ If you plan to use MotherDuck MCP with Claude Desktop, you will also need Claude
 - Add the following configuration to your `claude_desktop_config.json`:
 
 ```json
-"mcpServers": {
-  "mcp-server-motherduck": {
-    "command": "uvx",
-    "args": [
-      "mcp-server-motherduck",
-      "--db-path",
-      "md:",
-      "--motherduck-token",
-      "<YOUR_MOTHERDUCK_TOKEN_HERE>",
-    ],
+{
+  "mcpServers": {
+    "mcp-server-motherduck": {
+      "command": "uvx",
+      "args": [
+        "mcp-server-motherduck",
+        "--db-path",
+        "md:",
+        "--motherduck-token",
+        "<YOUR_MOTHERDUCK_TOKEN_HERE>"
+      ],
+    }
   }
 }
 ```


### PR DESCRIPTION
The example had some issues in the `JSON`
* Add missing `{` 
* Remove trailing `,` at the end of "<YOUR_MOTHERDUCK_TOKEN_HERE>"