### PR TITLE
Add read-only mode support for DuckDB connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ An MCP server implementation that interacts with DuckDB and MotherDuck databases
 - **Data sharing**: create and share databases
 - **SQL analytics**: use DuckDB's SQL dialect to query any size of data directly from your AI Assistant or IDE
 - **Serverless architecture**: run analytics without needing to configure instances or clusters
-- **Readonly connections**: Connect to a local duckdb in [readonly mode](https://duckdb.org/docs/stable/connect/concurrency.html)
 
 ## Components
 
@@ -239,7 +238,7 @@ Local DuckDB file:
 }
 ```
 
-Local DuckDB file in readonly mode:
+Local DuckDB file in [readonly mode](https://duckdb.org/docs/stable/connect/concurrency.html):
 
 ```json
 {
@@ -256,6 +255,14 @@ Local DuckDB file in readonly mode:
   }
 }
 ```
+
+**Note**: readonly mode for local file-backed DuckDB connections also makes use of
+short lived connections. Each time the query MCP tool is used a temporary,
+reaodnly connection is created + query is executed + connection is closed. This
+feature was motivated by a workflow where [DBT](https://www.getdbt.com) was for
+modeling data within duckdb and then an MCP client (Windsurf/Cline/Claude/Cursor)
+was used for exploring the database. The short lived connections allow each tool
+to run and then release their connection, allowing the next tool to connect.
 
 ## Example Queries
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ An MCP server implementation that interacts with DuckDB and MotherDuck databases
 - **Data sharing**: create and share databases
 - **SQL analytics**: use DuckDB's SQL dialect to query any size of data directly from your AI Assistant or IDE
 - **Serverless architecture**: run analytics without needing to configure instances or clusters
+- **Readonly connections**: Connect to a local duckdb in [readonly mode](https://duckdb.org/docs/stable/connect/concurrency.html)
 
 ## Components
 
@@ -31,13 +32,14 @@ All interactions with both DuckDB and MotherDuck are done through writing SQL qu
 ## Getting Started
 
 ### General Prerequisites
+
 - `uv` installed, you can install it using `pip install uv` or `brew install uv`
 
-If you plan to use the MCP with Claude Desktop or any other MCP comptabile client, the client need to be installed. 
+If you plan to use the MCP with Claude Desktop or any other MCP comptabile client, the client need to be installed.
 
 ### Prerequisites for DuckDB
 
-- No prerequisites. The MCP server can create an in-memory database on-the-fly 
+- No prerequisites. The MCP server can create an in-memory database on-the-fly
 - Or connect to an existing local DuckDB database file , or one stored on remote object storage (e.g., AWS S3).
 
 See [Connect to local DuckDB](#connect-to-local-duckdb).
@@ -54,7 +56,7 @@ See [Connect to local DuckDB](#connect-to-local-duckdb).
 
 2. Open Cursor:
 
-- To set it up globally for the first time, go to Settings->MCP and click on "+ Add new global MCP server". 
+- To set it up globally for the first time, go to Settings->MCP and click on "+ Add new global MCP server".
 - This will open a `mcp.json` file to which you add the following configuration:
 
 ```json
@@ -77,6 +79,7 @@ See [Connect to local DuckDB](#connect-to-local-duckdb).
 ### Usage with VS Code
 
 [![Install with UV in VS Code](https://img.shields.io/badge/VS_Code-UV-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=mcp-server-motherduck&config=%7B%22command%22%3A%22uvx%22%2C%22args%22%3A%5B%22mcp-server-motherduck%22%2C%22--db-path%22%2C%22md%3A%22%2C%22--motherduck-token%22%2C%22%24%7Binput%3Amotherduck_token%7D%22%5D%7D&inputs=%5B%7B%22type%22%3A%22promptString%22%2C%22id%22%3A%22motherduck_token%22%2C%22description%22%3A%22MotherDuck+Token%22%2C%22password%22%3Atrue%7D%5D) [![Install with UV in VS Code Insiders](https://img.shields.io/badge/VS_Code_Insiders-UV-24bfa5?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=mcp-server-motherduck&config=%7B%22command%22%3A%22uvx%22%2C%22args%22%3A%5B%22mcp-server-motherduck%22%2C%22--db-path%22%2C%22md%3A%22%2C%22--motherduck-token%22%2C%22%24%7Binput%3Amotherduck_token%7D%22%5D%7D&inputs=%5B%7B%22type%22%3A%22promptString%22%2C%22id%22%3A%22motherduck_token%22%2C%22description%22%3A%22MotherDuck+Token%22%2C%22password%22%3Atrue%7D%5D&quality=insiders)
+
 1. For the quickest installation, click one of the "Install with UV" buttons at the top of this README.
 
 ### Manual Installation
@@ -173,12 +176,13 @@ Optionally, you can add it to a file called `.vscode/mcp.json` in your workspace
 
 If the MCP server is exposed to third parties and should only have read access to data, we recommend using a read scaling token and running the MCP server in SaaS mode.
 
-**Read Scaling Tokens** are special access tokens that enable scalable read operations by allowing up to 4 concurrent read replicas, improving performance for multiple end users while *restricting write capabilities*. 
+**Read Scaling Tokens** are special access tokens that enable scalable read operations by allowing up to 4 concurrent read replicas, improving performance for multiple end users while *restricting write capabilities*.
 Refer to the [Read Scaling documentation](https://motherduck.com/docs/key-tasks/authenticating-and-connecting-to-motherduck/read-scaling/#creating-a-read-scaling-token) to learn how to create a read-scaling token.
 
 **SaaS Mode** in MotherDuck enhances security by restricting it's access to local files, databases, extensions, and configurations, making it ideal for third-party tools that require stricter environment protection. Learn more about it in the [SaaS Mode documentation](https://motherduck.com/docs/key-tasks/authenticating-and-connecting-to-motherduck/authenticating-to-motherduck/#authentication-using-saas-mode).
 
 **Secure Configuration**
+
 ```json
 {
   "mcpServers": {
@@ -202,6 +206,7 @@ Refer to the [Read Scaling documentation](https://motherduck.com/docs/key-tasks/
 To connect to a local DuckDB, instead of using the MotherDuck token, specify the path to your local DuckDB database file or use `:memory:` for an in-memory database.
 
 In-memory database:
+
 ```json
 {
   "mcpServers": {
@@ -218,6 +223,7 @@ In-memory database:
 ```
 
 Local DuckDB file:
+
 ```json
 {
   "mcpServers": {
@@ -227,6 +233,24 @@ Local DuckDB file:
         "mcp-server-motherduck",
         "--db-path",
         "/path/to/your/local.db"
+      ]
+    }
+  }
+}
+```
+
+Local DuckDB file in readonly mode:
+
+```json
+{
+  "mcpServers": {
+    "mcp-server-motherduck": {
+      "command": "uvx",
+      "args": [
+        "mcp-server-motherduck",
+        "--db-path",
+        "/path/to/your/local.db",
+        "--read-only"
       ]
     }
   }
@@ -294,10 +318,10 @@ To run the server from a local development environment, use the following config
     "mcp-server-motherduck": {
       "command": "uv",
       "args": [
-        "--directory", 
-        "/path/to/your/local/mcp-server-motherduck", 
-        "run", 
-        "mcp-server-motherduck", 
+        "--directory",
+        "/path/to/your/local/mcp-server-motherduck",
+        "run",
+        "mcp-server-motherduck",
         "--db-path",
         "md:",
         "--motherduck-token",

--- a/src/mcp_server_motherduck/__init__.py
+++ b/src/mcp_server_motherduck/__init__.py
@@ -42,7 +42,7 @@ def main():
     parser.add_argument(
         "--read-only",
         action="store_true",
-        help="Flag for connecting to DuckDB in read-only mode. Only supported for local DuckDB databases.",
+        help="Flag for connecting to DuckDB in read-only mode. Only supported for local DuckDB databases. Also makes use of short lived connections so multiple MCP clients or other systems can remain active (though each operation must be done sequentially).",
     )
 
     args = parser.parse_args()

--- a/src/mcp_server_motherduck/__init__.py
+++ b/src/mcp_server_motherduck/__init__.py
@@ -39,6 +39,12 @@ def main():
         choices=["markdown", "duckbox", "text"],
     )
 
+    parser.add_argument(
+        "--read-only",
+        action="store_true",
+        help="Flag for connecting to DuckDB in read-only mode. Only supported for local DuckDB databases.",
+    )
+
     args = parser.parse_args()
     logger.info("🦆 MotherDuck MCP Server v" + server.SERVER_VERSION)
     logger.info("Ready to execute SQL queries via DuckDB/MotherDuck")
@@ -51,6 +57,7 @@ def main():
             result_format=args.result_format,
             home_dir=args.home_dir,
             saas_mode=args.saas_mode,
+            read_only=args.read_only,
         )
     )
 

--- a/src/mcp_server_motherduck/server.py
+++ b/src/mcp_server_motherduck/server.py
@@ -53,6 +53,7 @@ class DatabaseClient:
                     config={
                         "custom_user_agent": f"mcp-server-motherduck/{SERVER_VERSION}"
                     },
+                    read_only=self._read_only,
                 )
                 conn.execute("SELECT 1")
                 conn.close()
@@ -61,6 +62,10 @@ class DatabaseClient:
                 logger.error(f"❌ Read-only check failed: {e}")
                 raise
 
+        if self._read_only:
+            raise ValueError(
+                "Read-only mode is only supported for local DuckDB databases. See `saas_mode` for similar functionality with MotherDuck."
+            )
         conn = duckdb.connect(
             self.db_path,
             config={"custom_user_agent": f"mcp-server-motherduck/{SERVER_VERSION}"},
@@ -118,7 +123,7 @@ class DatabaseClient:
             conn = duckdb.connect(
                 self.db_path,
                 config={"custom_user_agent": f"mcp-server-motherduck/{SERVER_VERSION}"},
-                read_only=True,
+                read_only=self._read_only,
             )
             q = conn.execute(query)
         else:


### PR DESCRIPTION
Introduced a new command-line argument `--read-only` to enable read-only mode for local DuckDB databases.