### PR TITLE
Fix missing pytz dependency for datetime queries

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
  "uvicorn>=0.34.0",
  "anyio>=4.8.0",
  "mcp>=1.9.4",
+ "pytz>=2025.2"
 ]
 
 [[project.authors]]


### PR DESCRIPTION
When querying tables with datetime fields using the MCP server in Cursor, I encountered the following error:

```
Error executing tool query: ❌ Error executing query: Invalid Input Error: Required module 'pytz' failed to import, due to the following Python exception:
ModuleNotFoundError: No module named 'pytz'
```

This error only occurred when selecting columns with datetime values. Queries without datetime fields worked as expected.

**Solution:**
Added the latest version of pytz to pyproject.toml to resolve the missing dependency.

**Verification:**
After updating the dependency, I was able to successfully run my local version of the mcp-server and query tables with datetime fields without errors.
