### PR TITLE
Update README.md to change mcpServers key to servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ See [Connect to local DuckDB](#connect-to-local-duckdb).
 
 ```json
 {
-  "mcpServers": {
+  "servers": {
     "mcp-server-motherduck": {
       "command": "uvx",
       "args": [
@@ -187,7 +187,7 @@ Optionally, you can add it to a file called `.vscode/mcp.json` in your workspace
 
 ```json
 {
-  "mcpServers": {
+  "servers": {
     "mcp-server-motherduck": {
       "command": "uvx",
       "args": [
@@ -219,7 +219,7 @@ Refer to the [Read Scaling documentation](https://motherduck.com/docs/key-tasks/
 
 ```json
 {
-  "mcpServers": {
+  "servers": {
     "mcp-server-motherduck": {
       "command": "uvx",
       "args": [
@@ -243,7 +243,7 @@ In-memory database:
 
 ```json
 {
-  "mcpServers": {
+  "servers": {
     "mcp-server-motherduck": {
       "command": "uvx",
       "args": [
@@ -260,7 +260,7 @@ Local DuckDB file:
 
 ```json
 {
-  "mcpServers": {
+  "servers": {
     "mcp-server-motherduck": {
       "command": "uvx",
       "args": [
@@ -277,7 +277,7 @@ Local DuckDB file in [readonly mode](https://duckdb.org/docs/stable/connect/conc
 
 ```json
 {
-  "mcpServers": {
+  "servers": {
     "mcp-server-motherduck": {
       "command": "uvx",
       "args": [
@@ -338,7 +338,7 @@ To run the server from a local development environment, use the following config
 
 ```json
  {
-  "mcpServers": {
+  "servers": {
     "mcp-server-motherduck": {
       "command": "uv",
       "args": [


### PR DESCRIPTION
This seems to be the required syntax for the latest VS Code