### PR TITLE
Refactor db_path handling to allow dynamically changing DB

### DIFF
--- a/src/mcp_server_motherduck/database.py
+++ b/src/mcp_server_motherduck/database.py
@@ -1,4 +1,5 @@
 import os
+import glob
 import duckdb
 from typing import Literal, Optional
 import io
@@ -13,54 +14,35 @@ logger = logging.getLogger("mcp_server_motherduck")
 class DatabaseClient:
     def __init__(
         self,
-        db_path: str | None = None,
         motherduck_token: str | None = None,
         home_dir: str | None = None,
         saas_mode: bool = False,
         read_only: bool = False,
     ):
         self._read_only = read_only
-        self.db_path, self.db_type = self._resolve_db_path_type(
-            db_path, motherduck_token, saas_mode
-        )
-        logger.info(f"Database client initialized in `{self.db_type}` mode")
-
+        self._motherduck_token = motherduck_token
+        self._saas_mode = saas_mode
+        
         # Set the home directory for DuckDB
         if home_dir:
             os.environ["HOME"] = home_dir
 
-        self.conn = self._initialize_connection()
+        logger.info("Database client initialized for dynamic connections")
 
-    def _initialize_connection(self) -> Optional[duckdb.DuckDBPyConnection]:
-        """Initialize connection to the MotherDuck or DuckDB database"""
-
-        logger.info(f"🔌 Connecting to {self.db_type} database")
-
-        if self.db_type == "duckdb" and self._read_only:
-            # check that we can connect, issue a `select 1` and then close + return None
-            try:
-                conn = duckdb.connect(
-                    self.db_path,
-                    config={
-                        "custom_user_agent": f"mcp-server-motherduck/{SERVER_VERSION}"
-                    },
-                    read_only=self._read_only,
-                )
-                conn.execute("SELECT 1")
-                conn.close()
-                return None
-            except Exception as e:
-                logger.error(f"❌ Read-only check failed: {e}")
-                raise
-
+    def _connect_to_database(self, db_path: str) -> duckdb.DuckDBPyConnection:
+        """Create a connection to the specified database"""
+        db_path, db_type = self._resolve_db_path_type(db_path, self._motherduck_token, self._saas_mode)
+        
+        logger.info(f"🔌 Connecting to {db_type} database: {db_path}")
+        
         conn = duckdb.connect(
-            self.db_path,
+            db_path,
             config={"custom_user_agent": f"mcp-server-motherduck/{SERVER_VERSION}"},
             read_only=self._read_only,
         )
 
-        logger.info(f"✅ Successfully connected to {self.db_type} database")
-
+        logger.info(f"✅ Successfully connected to {db_type} database")
+        
         return conn
 
     def _resolve_db_path_type(
@@ -100,32 +82,86 @@ class DatabaseClient:
 
         return db_path, "duckdb"
 
-    def _execute(self, query: str) -> str:
-        if self.conn is None:
-            # open short lived readonly connection, run query, close connection, return result
-            conn = duckdb.connect(
-                self.db_path,
-                config={"custom_user_agent": f"mcp-server-motherduck/{SERVER_VERSION}"},
-                read_only=self._read_only,
-            )
-            q = conn.execute(query)
-        else:
-            q = self.conn.execute(query)
-
-        out = tabulate(
-            q.fetchall(),
-            headers=[d[0] + "\n" + d[1] for d in q.description],
-            tablefmt="pretty",
-        )
-
-        if self.conn is None:
-            conn.close()
-
-        return out
-
-    def query(self, query: str) -> str:
+    def _execute(self, query: str, db_path: str) -> str:
+        """Execute a query on the specified database"""
+        conn = None
         try:
-            return self._execute(query)
+            conn = self._connect_to_database(db_path)
+            q = conn.execute(query)
+            
+            out = tabulate(
+                q.fetchall(),
+                headers=[d[0] + "\n" + d[1] for d in q.description],
+                tablefmt="pretty",
+            )
+            
+            return out
+            
+        finally:
+            if conn:
+                conn.close()
+                logger.info(f"🔌 Closed connection to database")
 
+    def query(self, query: str, db_path: str = ":memory:") -> str:
+        """Execute a query on the specified database path"""
+        try:
+            return self._execute(query, db_path)
         except Exception as e:
             raise ValueError(f"❌ Error executing query: {e}")
+    
+    def list_available_databases(self) -> str:
+        """List available databases including MotherDuck and local files"""
+        databases = []
+        
+        # Check for MotherDuck availability
+        if self._motherduck_token or os.getenv("motherduck_token"):
+            databases.append("📡 MotherDuck:\n  - md: (default MotherDuck database)\n  - md:database_name (specific MotherDuck database)")
+        
+        # Check for local DuckDB files
+        databases.append("\n💾 Local options:\n  - :memory: (in-memory database)")
+        
+        # Look for DuckDB files recursively in current directory
+        cwd = os.getcwd()
+        patterns = ["*.duckdb", "*.db", "*.duck"]
+        found_dbs = []
+        
+        for pattern in patterns:
+            # Recursive search using ** glob pattern
+            found_dbs.extend(glob.glob(os.path.join(cwd, "**", pattern), recursive=True))
+        
+        if found_dbs:
+            # Sort by path depth (files in current dir first) and then alphabetically
+            found_dbs.sort(key=lambda x: (x.count(os.sep), x))
+            databases.append("\n📁 Local DuckDB files found:")
+            for db_file in found_dbs[:20]:  # Limit to first 20 to avoid overwhelming output
+                rel_path = os.path.relpath(db_file, cwd)
+                databases.append(f"  - {rel_path}")
+            
+            if len(found_dbs) > 20:
+                databases.append(f"  ... and {len(found_dbs) - 20} more files")
+        
+        return "\n".join(databases)
+    
+    def validate_database_path(self, db_path: str) -> bool:
+        """Validate that a database path is accessible"""
+        # Special paths that are always valid
+        if db_path in [":memory:", "*"]:
+            return True
+        
+        # MotherDuck paths
+        if db_path.startswith("md:"):
+            if not (self._motherduck_token or os.getenv("motherduck_token")):
+                raise ValueError("MotherDuck token required for md: paths. Set motherduck_token environment variable or pass --motherduck-token")
+            return True
+        
+        # Local file paths
+        if os.path.exists(db_path):
+            return True
+        
+        # Try to create a test connection to validate
+        try:
+            conn = self._connect_to_database(db_path)
+            conn.close()
+            return True
+        except Exception as e:
+            raise ValueError(f"Cannot access database at '{db_path}': {str(e)}")


### PR DESCRIPTION
Solution for #18: allows changing the DB on the fly for each request. Opens the DB, queries, then closes it, to minimize the time the database file will be locked.