### PR TITLE
Output quoted column names if need be

### DIFF
--- a/src/mcp_server_motherduck/database.py
+++ b/src/mcp_server_motherduck/database.py
@@ -22,6 +22,17 @@ def quote_sql_identifier(value: str) -> str:
     return '"' + value.replace('"', '""') + '"'
 
 
+def identifier_needs_quoting(name: str, reserved_keywords: set[str]) -> bool:
+    """Check if a SQL identifier needs double-quoting to be used safely."""
+    if not name:
+        return True
+    if not re.match(r'^[a-zA-Z_][a-zA-Z0-9_]*$', name):
+        return True
+    if name.upper() in reserved_keywords:
+        return True
+    return False
+
+
 def _is_read_scaling_connection(conn: duckdb.DuckDBPyConnection) -> bool:
     """
     Check if a MotherDuck connection is using read-scaling.
@@ -78,6 +89,7 @@ class DatabaseClient:
 
         self.conn = None
         self._conn_initialized = False
+        self._cached_keywords: set[str] | None = None
 
     def _ensure_connected(self) -> None:
         """Lazily initialize the database connection on first use."""
@@ -445,6 +457,25 @@ class DatabaseClient:
             if self.conn is None:
                 conn.close()
 
+    def get_reserved_keywords(self) -> set[str]:
+        """Return the set of DuckDB reserved keywords, cached after first fetch."""
+        if self._cached_keywords is None:
+            try:
+                _, _, rows = self.execute_raw(
+                    "SELECT keyword_name FROM duckdb_keywords() WHERE keyword_category = 'reserved'"
+                )
+                self._cached_keywords = {row[0].upper() for row in rows}
+            except Exception:
+                logger.warning("Could not fetch duckdb_keywords(); reserved word detection disabled")
+                self._cached_keywords = set()
+        return self._cached_keywords
+
+    def quote_identifier_for_display(self, name: str) -> str:
+        """Return the identifier quoted if needed, or as-is if safe to use unquoted."""
+        if identifier_needs_quoting(name, self.get_reserved_keywords()):
+            return quote_sql_identifier(name)
+        return name
+
     def switch_database(self, path: str, read_only: bool = True) -> None:
         """
         Switch to a different primary database.
@@ -463,6 +494,7 @@ class DatabaseClient:
             except Exception:
                 pass  # Ignore close errors
             self.conn = None
+        self._cached_keywords = None
 
         # Update database configuration
         self._read_only = read_only

--- a/src/mcp_server_motherduck/instructions.py
+++ b/src/mcp_server_motherduck/instructions.py
@@ -25,6 +25,21 @@ INSTRUCTIONS_BASE = """Execute SQL queries against DuckDB and MotherDuck databas
 - Use double quotes (`"`) for identifiers with spaces/special characters or case-sensitivity
 - Use single quotes (`'`) for string literals
 
+### Identifier Quoting
+
+`list_tables` and `list_columns` return `name` values in SQL-ready form.
+Names that require quoting are already double-quoted — use them directly in SQL
+without adding additional quotes.
+
+Identifiers are quoted when they:
+- Contain special characters (hyphens, spaces, colons): `"ACSDT5Y2023_B19080-Data"`
+- Start with a digit: `"2023_sales"`
+- Are DuckDB reserved words: `"select"`, `"table"`, `"order"`
+- Need case preservation: `"firstName"` (DuckDB folds unquoted to lowercase)
+
+Best practice: call `list_tables`/`list_columns` before writing queries against
+unfamiliar databases, and use the returned names directly in your SQL.
+
 **Flexible Query Structure:**
 - Queries can start with `FROM`: `FROM my_table WHERE condition;`
 - `SELECT` without `FROM` for expressions: `SELECT 1 + 1 AS result;`

--- a/src/mcp_server_motherduck/tools/list_columns.py
+++ b/src/mcp_server_motherduck/tools/list_columns.py
@@ -57,10 +57,10 @@ def list_columns(
 
         _, _, rows = db_client.execute_raw(sql)
 
-        # Transform results
+        # Transform results — names are pre-quoted when they need it
         columns = [
             {
-                "name": row[0],
+                "name": db_client.quote_identifier_for_display(row[0]),
                 "type": row[1],
                 "nullable": bool(row[2]),
                 "comment": row[3] if row[3] else None,

--- a/src/mcp_server_motherduck/tools/list_tables.py
+++ b/src/mcp_server_motherduck/tools/list_tables.py
@@ -63,11 +63,11 @@ def list_tables(
 
         _, _, rows = db_client.execute_raw(sql)
 
-        # Transform results
+        # Transform results — names are pre-quoted when they need it
         tables = [
             {
                 "schema": row[0],
-                "name": row[1],
+                "name": db_client.quote_identifier_for_display(row[1]),
                 "type": row[2],
                 "comment": row[3] if row[3] else None,
             }

--- a/tests/e2e/test_catalog_tools.py
+++ b/tests/e2e/test_catalog_tools.py
@@ -256,6 +256,75 @@ async def test_tool_annotations_read_only_mode(readonly_client):
 
 
 @pytest.mark.asyncio
+async def test_list_tables_quotes_special_names(memory_client):
+    """list_tables returns pre-quoted names for tables with special characters."""
+    # Create tables with various naming patterns
+    await memory_client.call_tool_mcp(
+        "execute_query", {"sql": 'CREATE TABLE "hyphen-table" (id INTEGER)'}
+    )
+    await memory_client.call_tool_mcp(
+        "execute_query", {"sql": "CREATE TABLE safe_table (id INTEGER)"}
+    )
+
+    result = await memory_client.call_tool_mcp("list_tables", {"database": "memory"})
+    data = parse_json_result(result)
+    assert data["success"] is True
+
+    names = {t["name"] for t in data["tables"]}
+    # Hyphen table should be quoted
+    assert '"hyphen-table"' in names
+    # Safe table should not be quoted
+    assert "safe_table" in names
+
+
+@pytest.mark.asyncio
+async def test_list_columns_quotes_special_names(memory_client):
+    """list_columns returns pre-quoted names for columns with special characters."""
+    await memory_client.call_tool_mcp(
+        "execute_query",
+        {"sql": 'CREATE TABLE quote_col_test ("normal_col" INTEGER, "Unnamed: 12" VARCHAR)'},
+    )
+
+    result = await memory_client.call_tool_mcp(
+        "list_columns",
+        {"database": "memory", "table": "quote_col_test"},
+    )
+    data = parse_json_result(result)
+    assert data["success"] is True
+
+    col_names = [c["name"] for c in data["columns"]]
+    assert "normal_col" in col_names
+    assert '"Unnamed: 12"' in col_names
+
+
+@pytest.mark.asyncio
+async def test_quoted_names_work_in_queries(memory_client):
+    """Names returned by list_tables can be used directly in SQL queries."""
+    await memory_client.call_tool_mcp(
+        "execute_query",
+        {"sql": 'CREATE TABLE "special-table" (id INTEGER, val VARCHAR)'},
+    )
+    await memory_client.call_tool_mcp(
+        "execute_query",
+        {"sql": "INSERT INTO \"special-table\" VALUES (1, 'hello')"},
+    )
+
+    # Get the quoted name from list_tables
+    result = await memory_client.call_tool_mcp("list_tables", {"database": "memory"})
+    data = parse_json_result(result)
+    special = next(t for t in data["tables"] if "special" in t["name"])
+    quoted_name = special["name"]
+
+    # Use it directly in a query
+    query_result = await memory_client.call_tool_mcp(
+        "execute_query", {"sql": f"SELECT * FROM {quoted_name}"}
+    )
+    query_data = parse_json_result(query_result)
+    assert query_data["success"] is True
+    assert query_data["rowCount"] == 1
+
+
+@pytest.mark.asyncio
 async def test_catalog_tools_always_readonly(memory_client):
     """Catalog tools always have readOnlyHint=True."""
     tools = await memory_client.list_tools()

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,0 +1,1 @@
+# Unit tests

--- a/tests/unit/test_quoting.py
+++ b/tests/unit/test_quoting.py
@@ -1,0 +1,114 @@
+"""
+Unit tests for identifier quoting logic.
+"""
+
+import pytest
+
+from mcp_server_motherduck.database import (
+    DatabaseClient,
+    identifier_needs_quoting,
+    quote_sql_identifier,
+)
+
+
+class TestIdentifierNeedsQuoting:
+    """Tests for identifier_needs_quoting()."""
+
+    def test_simple_name(self):
+        assert identifier_needs_quoting("users", set()) is False
+
+    def test_underscore_name(self):
+        assert identifier_needs_quoting("my_table", set()) is False
+
+    def test_starts_with_underscore(self):
+        assert identifier_needs_quoting("_private", set()) is False
+
+    def test_hyphen(self):
+        assert identifier_needs_quoting("my-table", set()) is True
+
+    def test_space(self):
+        assert identifier_needs_quoting("my table", set()) is True
+
+    def test_colon(self):
+        assert identifier_needs_quoting("Unnamed: 12", set()) is True
+
+    def test_starts_with_digit(self):
+        assert identifier_needs_quoting("2023_sales", set()) is True
+
+    def test_empty(self):
+        assert identifier_needs_quoting("", set()) is True
+
+    def test_reserved_word(self):
+        reserved = {"SELECT", "FROM", "TABLE"}
+        assert identifier_needs_quoting("select", reserved) is True
+        assert identifier_needs_quoting("SELECT", reserved) is True
+        assert identifier_needs_quoting("Select", reserved) is True
+
+    def test_not_reserved(self):
+        reserved = {"SELECT", "FROM", "TABLE"}
+        assert identifier_needs_quoting("users", reserved) is False
+
+    def test_dot(self):
+        assert identifier_needs_quoting("schema.table", set()) is True
+
+    def test_at_sign(self):
+        assert identifier_needs_quoting("col@name", set()) is True
+
+    def test_hash(self):
+        assert identifier_needs_quoting("field#1", set()) is True
+
+
+class TestQuoteSqlIdentifier:
+    """Tests for quote_sql_identifier()."""
+
+    def test_simple(self):
+        assert quote_sql_identifier("users") == '"users"'
+
+    def test_with_hyphen(self):
+        assert quote_sql_identifier("my-table") == '"my-table"'
+
+    def test_escapes_internal_quotes(self):
+        assert quote_sql_identifier('my"table') == '"my""table"'
+
+    def test_empty(self):
+        assert quote_sql_identifier("") == '""'
+
+
+class TestDatabaseClientQuoting:
+    """Tests for DatabaseClient quoting methods using in-memory DuckDB."""
+
+    @pytest.fixture
+    def db_client(self):
+        return DatabaseClient(db_path=":memory:")
+
+    def test_get_reserved_keywords_returns_nonempty(self, db_client):
+        keywords = db_client.get_reserved_keywords()
+        assert len(keywords) > 0
+        assert "SELECT" in keywords
+        assert "FROM" in keywords
+        assert "TABLE" in keywords
+
+    def test_get_reserved_keywords_cached(self, db_client):
+        kw1 = db_client.get_reserved_keywords()
+        kw2 = db_client.get_reserved_keywords()
+        assert kw1 is kw2  # same object, not re-fetched
+
+    def test_quote_identifier_for_display_safe_name(self, db_client):
+        assert db_client.quote_identifier_for_display("users") == "users"
+
+    def test_quote_identifier_for_display_hyphen(self, db_client):
+        assert db_client.quote_identifier_for_display("my-table") == '"my-table"'
+
+    def test_quote_identifier_for_display_reserved_word(self, db_client):
+        assert db_client.quote_identifier_for_display("select") == '"select"'
+
+    def test_quote_identifier_for_display_digit_start(self, db_client):
+        assert db_client.quote_identifier_for_display("2023_sales") == '"2023_sales"'
+
+    def test_quote_identifier_for_display_census_example(self, db_client):
+        result = db_client.quote_identifier_for_display("ACSDT5Y2023_B19080-Data")
+        assert result == '"ACSDT5Y2023_B19080-Data"'
+
+    def test_quote_identifier_for_display_unnamed_column(self, db_client):
+        result = db_client.quote_identifier_for_display("Unnamed: 12")
+        assert result == '"Unnamed: 12"'


### PR DESCRIPTION
If (and only if) a column or table name must be quoted, the `list_columns` / `list_tables` tools will quote it, making it the case that the outputs of these tools can be directly used in other calls in all cases.

I decided to change the output of the `name` field in the existing tool calls rather than, say, adding a new `quotedName` field for two reasons:

1. Empirically, some tools and LLMs were already treating this field as though its output was safe to use unquoted; adding instructions to quote names decreased errors.
2. Adding a new field would add tokens to each tool call.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213823852701813