### PR TITLE
fix: redact motherduck_token from switch_database_connection response

### DIFF
--- a/src/mcp_server_motherduck/database.py
+++ b/src/mcp_server_motherduck/database.py
@@ -67,6 +67,10 @@ class DatabaseClient:
         self._motherduck_token = motherduck_token
         self._saas_mode = saas_mode
         self._motherduck_connection_parameters = motherduck_connection_parameters
+        # Preserve the raw user-supplied path for safe surfacing to clients.
+        # self.db_path may include the motherduck_token for MD connections, so it
+        # must never be returned in tool responses or logged.
+        self.user_db_path = db_path
         self.db_path, self.db_type = self._resolve_db_path_type(
             db_path, motherduck_token, saas_mode
         )
@@ -466,6 +470,7 @@ class DatabaseClient:
 
         # Update database configuration
         self._read_only = read_only
+        self.user_db_path = path
         self.db_path, self.db_type = self._resolve_db_path_type(
             path, self._motherduck_token, self._saas_mode
         )

--- a/src/mcp_server_motherduck/tools/switch_database_connection.py
+++ b/src/mcp_server_motherduck/tools/switch_database_connection.py
@@ -106,7 +106,9 @@ def switch_database_connection(
         warning = None
 
     try:
-        previous_db = db_client.db_path
+        # Use user_db_path (raw user input) rather than db_path, which for
+        # MotherDuck connections contains the motherduck_token query parameter.
+        previous_db = db_client.user_db_path
         db_client.switch_database(path, effective_read_only)
 
         result: dict[str, Any] = {

--- a/tests/e2e/test_switch_database_connection.py
+++ b/tests/e2e/test_switch_database_connection.py
@@ -269,3 +269,41 @@ class TestSwitchDatabaseConnectionToolAvailability:
         tools = await memory_client_with_switch.list_tools()
         tool_names = [t.name for t in tools]
         assert "switch_database_connection" in tool_names
+
+
+class TestSwitchDatabaseConnectionTokenRedaction:
+    """The response must not leak the MotherDuck token in `previousDatabase`."""
+
+    @pytest.mark.asyncio
+    async def test_motherduck_token_not_in_switch_response(self, tmp_path):
+        """Switching away from a MotherDuck connection must not expose the token."""
+        from fastmcp import Client
+
+        from mcp_server_motherduck.server import create_mcp_server
+
+        # Create a local target so the switch itself does not touch the network.
+        target_db = tmp_path / "target.duckdb"
+        duckdb.connect(str(target_db)).close()
+
+        sentinel_token = "sentinel-token-should-not-appear-in-responses"
+        mcp = create_mcp_server(
+            db_path="md:fake_db",
+            motherduck_token=sentinel_token,
+            allow_switch_databases=True,
+        )
+
+        async with Client(mcp) as client:
+            result = await client.call_tool_mcp(
+                "switch_database_connection",
+                {"path": str(target_db)},
+            )
+
+        text = get_result_text(result)
+        assert sentinel_token not in text, (
+            f"MotherDuck token leaked in switch_database_connection response: {text}"
+        )
+
+        data = parse_json_result(result)
+        assert "motherduck_token=" not in data.get("previousDatabase", ""), (
+            "previousDatabase must not contain the motherduck_token query parameter"
+        )


### PR DESCRIPTION
## Summary

`switch_database_connection` returned `DatabaseClient.db_path` as the `previousDatabase` field. For MotherDuck connections, that string is the fully-resolved URL including `?motherduck_token=<token>`, so the token was exposed in the tool response.

## Impact

- Requires `--allow-switch-databases` (off by default).
- Any switch whose previous connection was MotherDuck leaks the token. Because `self._motherduck_token` is retained across switches, any switch sequence that passes through a MotherDuck connection leaks on the subsequent switch — not only when the server starts with `md:`.
- Exposure surface: the LLM client's context window (stdio transport) or the HTTP response body (HTTP transport).

## Fix

Preserve the raw user-supplied path as `DatabaseClient.user_db_path` and surface that in the tool response. `self.db_path` still holds the resolved URL for `duckdb.connect(...)`.

- `database.py` — set `self.user_db_path` in `__init__` and `switch_database`.
- `tools/switch_database_connection.py` — use `user_db_path` for `previousDatabase`.

## Test plan

- [x] Adds `test_motherduck_token_not_in_switch_response` — asserts no token substring appears in the response and that `previousDatabase` contains no `motherduck_token=` query parameter.
- [x] Existing `test_switch_between_databases` already covers the `switch_database` edit site via a two-switch sequence (removing the new assignment makes it fail).
- [x] Full suite: 84 passed, 56 skipped (MotherDuck-token-gated), 2 pre-existing S3 failures unrelated to this change.
- [x] `ruff check` and `ruff format --check` pass.

## Out-of-scope follow-up

A secondary leak channel exists via `str(e)` in tool error handlers: if a DuckDB exception embeds the connection string, the token could leak through the exception path. Not addressed here; correct fix is to separate `motherduck_token` from the connection URL entirely — bigger refactor.