### PR TITLE
fix: use conn.executescript() instead of conn.execute() for multi-statement SQL

### DIFF
--- a/src/mcp_server_motherduck/database.py
+++ b/src/mcp_server_motherduck/database.py
@@ -247,8 +247,8 @@ class DatabaseClient:
                 logger.info("Executing init SQL string")
                 sql_content = self._init_sql
 
-            # Execute the SQL
-            conn.execute(sql_content)
+            # Execute the SQL (using executescript to support multiple statements)
+            conn.executescript(sql_content)
             logger.info("Init SQL executed successfully")
 
         except Exception as e:


### PR DESCRIPTION
## Summary
- Change conn.execute(sql_content) to conn.executescript(sql_content) in _execute_init_sql to support multi-statement SQL scripts

## Why
Issue #79: DuckDBPyConnection.execute() only executes the first statement before a semicolon in multi-statement SQL scripts. executescript() is specifically designed for executing multi-statement SQL scripts.

## Validation
- [x] Syntax check passed
- [x] Fix pushed to fork