### PR TITLE
Revert "fix: use conn.executescript() instead of conn.execute() for multi-statement SQL"

### DIFF
--- a/src/mcp_server_motherduck/database.py
+++ b/src/mcp_server_motherduck/database.py
@@ -251,8 +251,8 @@ class DatabaseClient:
                 logger.info("Executing init SQL string")
                 sql_content = self._init_sql
 
-            # Execute the SQL (using executescript to support multiple statements)
-            conn.executescript(sql_content)
+            # Execute the SQL
+            conn.execute(sql_content)
             logger.info("Init SQL executed successfully")
 
         except Exception as e:


### PR DESCRIPTION
Reverts motherduckdb/mcp-server-motherduck#85. 

executescript() doesn't exist - I also can't reproduce the issue described in https://github.com/motherduckdb/mcp-server-motherduck/issues/79